### PR TITLE
Revert #4012 and #4010 (merged with failing CI)

### DIFF
--- a/kubernetes/monitoring/node-exporter/node-exporter-daemonset.yaml
+++ b/kubernetes/monitoring/node-exporter/node-exporter-daemonset.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: prometheus-node-exporter
-          image: prom/node-exporter:v1.11.1
+          image: prom/node-exporter:v1.10.2
           imagePullPolicy: Always
           args:
             - --path.procfs=/proc

--- a/kubernetes/rabbitmq/Dockerfile
+++ b/kubernetes/rabbitmq/Dockerfile
@@ -1,4 +1,4 @@
-FROM rabbitmq:4.3.2-management-alpine
+FROM rabbitmq:4.1.4-management-alpine
 ARG BUILD_DATE
 ARG VCS_REF
 


### PR DESCRIPTION
CIがfailの状態でマージされた #4012 (rabbitmq v4.3.2) と #4010 (prom/node-exporter v1.11.1) をrevertします。CIがpassする状態に戻してから再検討します。