### PR TITLE
ci(pmd): exclude ImplicitFunctionalInterface rule

### DIFF
--- a/.github/pmdrule.xml
+++ b/.github/pmdrule.xml
@@ -7,5 +7,6 @@
   <description>My custom rules</description>
   <rule ref="category/java/bestpractices.xml">
     <exclude name="GuardLogStatement" />
+    <exclude name="ImplicitFunctionalInterface" />
   </rule>
 </ruleset>

--- a/.github/workflows/pmd.yml
+++ b/.github/workflows/pmd.yml
@@ -12,7 +12,7 @@ on:
       - "**.java"
       - "application/**"
       - ".github/workflows/pmd.yml"
-      - ".github/pmdrule.yml"
+      - ".github/pmdrule.xml"
   pull_request:
     # The branches below must be a subset of the branches above
     branches: ["master"]
@@ -20,7 +20,7 @@ on:
       - "**.java"
       - "application/**"
       - ".github/workflows/pmd.yml"
-      - ".github/pmdrule.yml"
+      - ".github/pmdrule.xml"
 
 permissions:
   contents: read


### PR DESCRIPTION
## 概要
PMD 7.24.0 で追加された `ImplicitFunctionalInterface` ルールが、全Quarkusモジュールの MicroProfile REST Client インターフェース（`*DeliverService` 等の単一メソッド interface）を一斉に違反検出し、master の pmd チェックが恒常的に fail → 全PRをブロックしていました。

これらは REST クライアント定義であり関数型インターフェースとして意図したものではないため、ルールの誤検知（false positive）です。既存の `GuardLogStatement` 除外と同形式で当ルールを除外します。

## 変更
- `.github/pmdrule.xml` に `<exclude name="ImplicitFunctionalInterface" />` を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)