### PR TITLE
ci(codacy): disambiguate SARIF runs before upload

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -52,6 +52,15 @@ jobs:
           # This will handover control about PR rejection to the GitHub side
           max-allowed-issues: 2147483647
 
+      # Give each SARIF run a distinct automationDetails.id so the upload does not
+      # fail when Codacy emits multiple runs (one per tool) in a single file.
+      # See https://github.blog/changelog/2025-07-21-code-scanning-will-stop-combining-multiple-sarif-runs-uploaded-in-the-same-sarif-file/
+      - name: Disambiguate SARIF runs
+        run: |
+          jq '.runs |= [ to_entries[] | .value.automationDetails.id = "codacy/\(.value.tool.driver.name // "tool")-\(.key)/" | .value ]' \
+            results.sarif > results.disambiguated.sarif
+          mv results.disambiguated.sarif results.sarif
+
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
         uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
## 概要
Codacy CLI は複数ツールの結果を1つの SARIF ファイル（run複数）として出力します。GitHub の 2025-07-21 の仕様変更により、`github/codeql-action/upload-sarif` は同一カテゴリの複数 run を拒否するようになり、全PR・master で Codacy Security Scan が fail していました。

エラー: `The CodeQL Action does not support uploading multiple SARIF runs with the same category.`

## 変更
- アップロード前に jq で各 run に固有の `automationDetails.id`（ツール名 + run index）を付与する後処理ステップを追加

参考: https://github.blog/changelog/2025-07-21-code-scanning-will-stop-combining-multiple-sarif-runs-uploaded-in-the-same-sarif-file/

🤖 Generated with [Claude Code](https://claude.com/claude-code)