### PR TITLE
ci(docker): merge Snyk SARIF files into a single run before upload

### DIFF
--- a/.github/workflows/docker-image-ci.yml
+++ b/.github/workflows/docker-image-ci.yml
@@ -254,7 +254,34 @@ jobs:
       - name: rename sarif file
         run: mv snyk.sarif postmannewman-quarkus.sarif
 
-      - name: Upload result to GitHub Code Scanning - postmannewman-quarkus
+      # Merge every per-image Snyk SARIF into a single run. Uploading the raw
+      # files separately exceeds GitHub's limit of 20 runs per SARIF upload
+      # (8 files yield 23 runs), so the upload was rejected. Combining the
+      # results.* arrays into one run keeps a single run while preserving all
+      # findings.
+      - name: Merge SARIF files
+        run: |
+          jq -s '
+            ( [ .[].runs[] ] ) as $runs
+            | {
+                "$schema": .[0]["$schema"],
+                version: .[0].version,
+                runs: [
+                  {
+                    tool: {
+                      driver: (
+                        $runs[0].tool.driver
+                        | .rules = ([ $runs[].tool.driver.rules // [] ] | add | unique_by(.id))
+                      )
+                    },
+                    results: [ $runs[].results[] ]
+                  }
+                ]
+              }
+          ' *.sarif > merged.sarif
+
+      - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: ./
+          sarif_file: merged.sarif
+          category: snyk-docker


### PR DESCRIPTION
## 概要
Docker Image CI の build ジョブは各イメージに Snyk を実行し、`sarif_file: ./` で生成された全 SARIF ファイルを一括アップロードしていました。8ファイル合計23 run が GitHub の「1アップロード20 run上限」に抵触し、`rejecting SARIF, as there are more runs than allowed (23 > 20)` で build チェックが全PR・master で fail していました。

## 変更
- アップロード前に jq で全 SARIF の results（と重複排除した rules）を単一 run に統合する `Merge SARIF files` ステップを追加
- アップロードに固定 category `snyk-docker` を付与

jqロジックはローカルで検証済み（複数runの結果統合・rules重複排除・schema/version保持を確認）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)