### PR TITLE
ci(chaos-mesh): update Chaos Mesh to 2.7.1

### DIFF
--- a/.github/workflows/kind-chaos-mesh-ci.yml
+++ b/.github/workflows/kind-chaos-mesh-ci.yml
@@ -13,7 +13,7 @@ on:
       - ".github/workflows/kind-chaos-mesh-ci.yml"
 
 env:
-  CHAOS_MESH_VERSION: 2.7.0
+  CHAOS_MESH_VERSION: 2.7.1
 
 jobs:
   chaos-mesh-ci:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Sample web application based on k8s. Focus on connecting components, setting k8s
 [![Support Quarkus Version](https://img.shields.io/badge/Quarkus-2.16.12-yellow.svg?style=flat\&logo=Quarkus)](https://github.com/yurake/k8s-3tier-webapp/actions?query=workflow%3A%22Java+CI%22)
 [![Support Kubernetes Version](https://img.shields.io/badge/Kubernetes-1.35.0-yellow.svg?style=flat\&logo=Kubernetes)](https://github.com/yurake/k8s-3tier-webapp/actions?query=workflow%3A%22Minikube+CI%22)
 [![Support Minikube Version](https://img.shields.io/badge/Minikube-1.35.0-yellow.svg?style=flat\&logo=Kubernetes)](https://github.com/yurake/k8s-3tier-webapp/actions?query=workflow%3A%22Minikube+CI%22)
-[![Support kind Version](https://img.shields.io/badge/kind-2.7.0-yellow.svg?style=flat\&logo=Kubernetes)](https://github.com/yurake/k8s-3tier-webapp/actions?query=workflow%3A%22kind+CI%22)
+[![Support kind Version](https://img.shields.io/badge/kind-2.7.1-yellow.svg?style=flat\&logo=Kubernetes)](https://github.com/yurake/k8s-3tier-webapp/actions?query=workflow%3A%22kind+CI%22)
 
 [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE/)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fyurake%2Fk8s-3tier-webapp.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fyurake%2Fk8s-3tier-webapp?ref=badge_shield)  


### PR DESCRIPTION
## 概要
停滞していた自動更新PR #3617（chaos-mesh 2.7.0→2.7.1）は古すぎて master とコンフリクトしていたため、同じ変更を最新 master 上で作り直しました。#3617 はクローズします。

## 変更
- `.github/workflows/kind-chaos-mesh-ci.yml`: `CHAOS_MESH_VERSION` 2.7.0 → 2.7.1
- `README.md`: kind バッジ 2.7.0 → 2.7.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)