### PR TITLE
docs(readme): update DeepSource badge URLs to app.deepsource.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Sample web application based on k8s. Focus on connecting components, setting k8s
 [![CodeFactor](https://www.codefactor.io/repository/github/yurake/k8s-3tier-webapp/badge)](https://www.codefactor.io/repository/github/yurake/k8s-3tier-webapp) [![Maintainability](https://api.codeclimate.com/v1/badges/64a1de96c5eb777b9db1/maintainability)](https://codeclimate.com/github/yurake/k8s-3tier-webapp/maintainability)
 [![codebeat badge](https://codebeat.co/badges/e0bfc464-3370-467d-910f-ade9d83265b1)](https://codebeat.co/projects/github-com-yurake-k8s-3tier-webapp-master)
 [![codecov](https://codecov.io/gh/yurake/k8s-3tier-webapp/branch/master/graph/badge.svg)](https://codecov.io/gh/yurake/k8s-3tier-webapp)
-[![DeepSource Active Issues](https://deepsource.io/gh/yurake/k8s-3tier-webapp.svg/?label=active+issues\&show_trend=true\&token=Y64jIS9a54isgV4hi4_uuerZ)](https://deepsource.io/gh/yurake/k8s-3tier-webapp/?ref=repository-badge)
-[![DeepSource Resluved Issues](https://deepsource.io/gh/yurake/k8s-3tier-webapp.svg/?label=resolved+issues\&show_trend=true\&token=Y64jIS9a54isgV4hi4_uuerZ)](https://deepsource.io/gh/yurake/k8s-3tier-webapp/?ref=repository-badge)
+[![DeepSource Active Issues](https://app.deepsource.com/gh/yurake/k8s-3tier-webapp.svg/?label=active+issues\&show_trend=true\&token=Y64jIS9a54isgV4hi4_uuerZ)](https://app.deepsource.com/gh/yurake/k8s-3tier-webapp/?ref=repository-badge)
+[![DeepSource Resolved Issues](https://app.deepsource.com/gh/yurake/k8s-3tier-webapp.svg/?label=resolved+issues\&show_trend=true\&token=Y64jIS9a54isgV4hi4_uuerZ)](https://app.deepsource.com/gh/yurake/k8s-3tier-webapp/?ref=repository-badge)
 [![Cypress](https://img.shields.io/endpoint?url=https://dashboard.cypress.io/badge/detailed/7rgxn6/master\&style=flat\&logo=cypress)](https://dashboard.cypress.io/projects/7rgxn6/runs)  
 
 [![Support JVM Version](https://img.shields.io/badge/JVM-17-yellow.svg?style=flat\&logo=Java)](https://github.com/yurake/k8s-3tier-webapp/actions?query=workflow%3A%22Java+CI%22)


### PR DESCRIPTION
## 概要

DeepSource バッジ（Active / Resolved Issues）の画像URL・リンクURLを、旧ホスト `deepsource.io` から新ホスト `app.deepsource.com` へ更新する。

## 背景

- `https://deepsource.io/gh/...` は **HTTP 302** で `https://app.deepsource.com/gh/...` にリダイレクトされる
- 現状リダイレクト経由で表示できているが、旧ホスト停止リスクを避けるため新URLへ直接更新

## 変更内容

- DeepSource Active / Resolved Issues 両バッジの画像URL・リンクURLを `app.deepsource.com` に更新
- ラベルのタイポ "Resluved" → "Resolved" を修正

Closes #4031

🤖 Generated with [Claude Code](https://claude.com/claude-code)