### PR TITLE
docs(readme): remove non-functional Codacy coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Sample web application based on k8s. Focus on connecting components, setting k8s
 [![pages-build-deployment](https://github.com/yurake/k8s-3tier-webapp/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/yurake/k8s-3tier-webapp/actions/workflows/pages/pages-build-deployment)  
 
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/2844382aa110487e94bba8369267476e)](https://www.codacy.com/gh/yurake/k8s-3tier-webapp/dashboard?utm_source=github.com\&utm_medium=referral\&utm_content=yurake/k8s-3tier-webapp\&utm_campaign=Badge_Grade)
-[![Codacy Badge](https://app.codacy.com/project/badge/Coverage/2844382aa110487e94bba8369267476e)](https://www.codacy.com/gh/yurake/k8s-3tier-webapp/dashboard?utm_source=github.com\&utm_medium=referral\&utm_content=yurake/k8s-3tier-webapp\&utm_campaign=Badge_Coverage)
 [![CodeFactor](https://www.codefactor.io/repository/github/yurake/k8s-3tier-webapp/badge)](https://www.codefactor.io/repository/github/yurake/k8s-3tier-webapp) [![Maintainability](https://api.codeclimate.com/v1/badges/64a1de96c5eb777b9db1/maintainability)](https://codeclimate.com/github/yurake/k8s-3tier-webapp/maintainability)
 [![codebeat badge](https://codebeat.co/badges/e0bfc464-3370-467d-910f-ade9d83265b1)](https://codebeat.co/projects/github-com-yurake-k8s-3tier-webapp-master)
 [![codecov](https://codecov.io/gh/yurake/k8s-3tier-webapp/branch/master/graph/badge.svg)](https://codecov.io/gh/yurake/k8s-3tier-webapp)


### PR DESCRIPTION
## 概要

常に 0% を表示している Codacy Coverage バッジを README から削除する。

## 背景・調査結果

- Codacy Coverage バッジ画像は HTTP 200 で返るが、値が常に **0%**
- `codacy.yml` を確認したところ、**カバレッジレポートのアップロードステップが存在しない**（Codacy Analysis CLI によるセキュリティスキャンと SARIF アップロードのみ）
- カバレッジは既に **codecov（96%）** が担っており、Codacy Coverage は実質機能していない誤解を招くバッジ

## 変更内容

- Codacy Coverage バッジ行を削除
- Codacy Grade バッジ（A、正常）は維持

## 補足

カバレッジ連携を Codacy 側で復旧する選択肢もあったが、codecov と重複するため削除を選択。

Closes #4032

🤖 Generated with [Claude Code](https://claude.com/claude-code)