### PR TITLE
ci(minikube): pin kubernetes-version to a minikube-supported release

### DIFF
--- a/.github/workflows/minikube-quarkus-ci.yml
+++ b/.github/workflows/minikube-quarkus-ci.yml
@@ -32,7 +32,7 @@ jobs:
         uses: medyagh/setup-minikube@v0.0.21
         with:
           minikube-version: 1.37.0
-          kubernetes-version: 1.37.0
+          kubernetes-version: 1.34.0
           driver: docker
           container-runtime: docker
           cpus: 2

--- a/.github/workflows/minikube-security-ci.yml
+++ b/.github/workflows/minikube-security-ci.yml
@@ -22,7 +22,7 @@ jobs:
         uses: medyagh/setup-minikube@v0.0.21
         with:
           minikube-version: 1.37.0
-          kubernetes-version: 1.37.0
+          kubernetes-version: 1.34.0
           driver: docker
           container-runtime: docker
           cpus: 2

--- a/.github/workflows/minikube-stress-ci.yml
+++ b/.github/workflows/minikube-stress-ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: medyagh/setup-minikube@v0.0.21
         with:
           minikube-version: 1.37.0
-          kubernetes-version: 1.37.0
+          kubernetes-version: 1.34.0
           driver: docker
           container-runtime: docker
           cpus: 2

--- a/.github/workflows/minikube-yaml-ci.yml
+++ b/.github/workflows/minikube-yaml-ci.yml
@@ -22,7 +22,7 @@ jobs:
         uses: medyagh/setup-minikube@v0.0.21
         with:
           minikube-version: 1.37.0
-          kubernetes-version: 1.37.0
+          kubernetes-version: 1.34.0
           driver: docker
           container-runtime: docker
           cpus: 2


### PR DESCRIPTION
## 概要
check-for-update 自動更新（#3972）が minikube-version と kubernetes-version を両方 1.37.0 に更新しましたが、**1.37.0 は minikube のリリース番号であり Kubernetes のバージョンではありません**。minikube 1.37.0 がサポートする Kubernetes は最新で v1.34.0 のため、`kubernetes-version: 1.37.0` だと全ての minikube 系 CI が `K8S_NEW_UNSUPPORTED`（exit 106）で失敗します。

実際、redis(#3718)・grafana(#3717)・hazelcast など無関係な複数PRで minikube-yaml-ci が一斉に落ちていました。

## 変更
- `minikube-{yaml,quarkus,stress,security}-ci.yml`: `kubernetes-version` を 1.37.0 → **1.34.0** に修正（`minikube-version` は 1.37.0 のまま）

🤖 Generated with [Claude Code](https://claude.com/claude-code)