### PR TITLE
ci(cypress): fix EINTEGRITY for debug@3.2.7 in cypress lockfile

### DIFF
--- a/kubernetes/monitoring/test/cypress/package-lock.json
+++ b/kubernetes/monitoring/test/cypress/package-lock.json
@@ -61,7 +61,7 @@
     "node_modules/@cypress/xvfb/node_modules/debug": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
       "dependencies": {
         "ms": "^2.1.1"


### PR DESCRIPTION
## 概要

master で連続失敗している **Cypress CI**（管理外エラー）を解消する。

## 原因

`npm install` 時に `npm error code EINTEGRITY` が発生:

```
debug@3.2.7 (@cypress/xvfb の推移的依存)
wanted sha512-mel+jf7... but got sha512-CFjzYY...
```

`kubernetes/monitoring/test/cypress/package-lock.json` に記録された
`debug@3.2.7` の integrity チェックサムが、npm レジストリ上の実体と
一致しなくなっていた。

## 対応

該当 1 行の integrity ハッシュのみを、レジストリの現行値
（`npm view debug@3.2.7 dist.integrity` で確認した
`sha512-CFjzYY...`）に置換。依存ツリーは変更しないため、新たな
advisory を持ち込まない。ローカルで `npm ci` 成功（exit 0）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)