### PR TITLE
fix(build): fix JaCoCo double instrumentation and 0% coverage

### DIFF
--- a/application/parent-pom/pom.xml
+++ b/application/parent-pom/pom.xml
@@ -81,11 +81,15 @@
 			<artifactId>quarkus-junit5-mockito</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>io.quarkus</groupId>
-			<artifactId>quarkus-jacoco</artifactId>
-			<scope>test</scope>
-		</dependency>
+		<!--
+			The quarkus-jacoco extension is intentionally NOT used here. With
+			Quarkus 3.29 it only instruments @QuarkusTest classes and, in this
+			project, recorded no coverage at all (0%). It also conflicts with the
+			jacoco-maven-plugin prepare-agent goal (double instrumentation -> test
+			JVM crashes with "Failed to initialize JaCoCo"). Coverage is instead
+			produced by the jacoco-maven-plugin offline agent configured below,
+			which covers both plain JUnit and @QuarkusTest classes.
+		-->
 		<dependency>
 			<groupId>io.quarkus</groupId>
 			<artifactId>quarkus-arc</artifactId>
@@ -172,6 +176,18 @@
 						<exclude>**/*__MapperGenerated*.class</exclude>
 					</excludes>
 				</configuration>
+				<!--
+					Offline instrumentation via the prepare-agent goal. This is the
+					sole JaCoCo agent for tests; the quarkus-jacoco extension is
+					deliberately not on the classpath (see the dependencies section)
+					to avoid double instrumentation.
+
+					Note: we intentionally do NOT set exclClassLoaders. That option
+					(only needed alongside the quarkus-jacoco extension) excludes the
+					QuarkusClassLoader and, with the standalone agent, would drop all
+					@QuarkusTest coverage to 0%. Without it, both plain JUnit and
+					@QuarkusTest classes are instrumented correctly.
+				-->
 				<executions>
 					<execution>
 						<id>default-prepare-agent</id>
@@ -179,7 +195,6 @@
 							<goal>prepare-agent</goal>
 						</goals>
 						<configuration>
-							<exclClassLoaders>*QuarkusClassLoader</exclClassLoaders>
 							<destFile>${project.build.directory}/jacoco-quarkus.exec</destFile>
 							<append>true</append>
 						</configuration>


### PR DESCRIPTION
## 概要

Codacy Coverage バッジが 0% になっていた根本原因を修正し、カバレッジが正しく計測・送信されるようにする。

Closes #4032

## 背景・調査

調査の結果、0% は「URLの問題」ではなく **Java CI が JaCoCo 初期化エラーでクラッシュし、カバレッジが一度も送信されていなかった**ことが原因と判明した。

### 根本原因: JaCoCo の二重計装
[application/parent-pom/pom.xml](application/parent-pom/pom.xml) で以下の **2つの計装方式が同時適用**されていた:
- `quarkus-jacoco` 拡張（依存）
- `jacoco-maven-plugin` の `prepare-agent`（オフライン javaagent）

これによりテストクラスが二重計装され、CI の JVM 上で `BootstrapMethodError` → `Failed to initialize JaCoCo` でテストが異常終了していた（Quarkus 公式も[同時使用は計装エラーの原因](https://quarkus.io/guides/tests-with-coverage)と明記）。

### さらに判明した点（ローカル検証）
| 構成 | 通常JUnit | @QuarkusTest |
|---|---|---|
| `quarkus-jacoco` 拡張 | 対象外 | 本環境では 0%（機能せず） |
| `prepare-agent` + `exclClassLoaders` | OK | 0%（QuarkusClassLoader除外のため） |
| **`prepare-agent`（exclClassLoaders無し）** | OK | OK |

`exclClassLoaders=*QuarkusClassLoader` は拡張併用時のみ必要な設定で、単独agent構成では `@QuarkusTest` クラスの計装まで除外してしまっていた。

## 変更内容

1. `quarkus-jacoco` 拡張を削除（二重計装の解消）
2. `jacoco-maven-plugin` の `prepare-agent` に一本化
3. `exclClassLoaders=*QuarkusClassLoader` を削除（@QuarkusTest含め全計装）
4. 経緯を pom にコメントで明記

## 検証（ローカル, JDK21）

- 修正前: `Failed to initialize JaCoCo` でテストクラッシュ
- 修正後: webapp-service でテスト全通過、**JaCoCo line/branch カバレッジ 100%**（修正前 0%）
- クラス別でも `@QuarkusTest` 対象（ServiceSocket 等）が 0% → 100% に改善

これにより Java CI 実行時に Codacy へ実データが送信され、Coverage バッジが機能するようになる。

## 補足

- `consumer-redis-quarkus` 等、テストが本番クラスを呼んでいないモジュールは依然 0% だが、これは計装ではなくテスト内容の問題（本PRのスコープ外）。
- 本修正は parent-pom のため全 Quarkus モジュールに波及する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)