### PR TITLE
chore(deps): update grafana to 13.0.2

### DIFF
--- a/kubernetes/monitoring/grafana/grafana-deployment.yaml
+++ b/kubernetes/monitoring/grafana/grafana-deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: grafana
-          image: grafana/grafana:11.6.16
+          image: grafana/grafana:13.0.2
           imagePullPolicy: Always
           ports:
             - containerPort: 3000


### PR DESCRIPTION
## 概要
停滞していた #3717（grafana monorepo major, 11.6.15→13.0.2）は古すぎて master とコンフリクトしていたため、同じメジャー更新を最新 master（grafana 11.6.16）上で作り直しました。#3717 はクローズします。

## 変更
- `kubernetes/monitoring/grafana/grafana-deployment.yaml`: grafana 11.6.16 → 13.0.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)