### PR TITLE
ci(cypress): migrate cypress.json to cypress.config.js

### DIFF
--- a/kubernetes/monitoring/test/cypress/cypress.config.js
+++ b/kubernetes/monitoring/test/cypress/cypress.config.js
@@ -1,0 +1,9 @@
+const { defineConfig } = require("cypress");
+
+module.exports = defineConfig({
+  projectId: "7rgxn6",
+  e2e: {
+    specPattern: "cypress/integration/**/*.{js,jsx,ts,tsx}",
+    supportFile: false,
+  },
+});

--- a/kubernetes/monitoring/test/cypress/cypress.json
+++ b/kubernetes/monitoring/test/cypress/cypress.json
@@ -1,3 +1,0 @@
-{
-  "projectId": "7rgxn6"
-}


### PR DESCRIPTION
## 概要

master で失敗している **Cypress CI**（管理外エラー）の最終解消。

## 経緯

直前の PR #4043 で lockfile の EINTEGRITY を修正し `npm install` を
通過したことで、その先に隠れていた実行時エラーが顕在化した:

```
Cypress version 10.0.0 no longer supports cypress.json.
Please run cypress open to launch the migration tool ...
##[error]Could not find Cypress test run results
```

本プロジェクトは `cypress@^12.17.4` を使用しているが、設定が
旧 `cypress.json` 形式のまま残っていた。

## 対応

- `cypress.json` を削除し、`cypress.config.js` を新規作成
- `projectId` を引き継ぎ、`specPattern` で既存の
  `cypress/integration/**` を維持
- support ファイルは存在しないため `supportFile: false`

ローカルで `cypress.json no longer supports` エラーが消えることを
確認済み（残るローカルの `--no-sandbox` エラーは macOS 固有の
バイナリ起動問題で、CI の Linux runner では発生しない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)