### PR TITLE
ci(java): migrate to official graalvm/setup-graalvm to fix CgroupInfo NPE

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -25,11 +25,11 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup GraalVM
-        uses: DeLaGuardo/setup-graalvm@5.0
+        uses: graalvm/setup-graalvm@v1
         with:
-          graalvm: "22.2.0"
-          java: "java17"
-          arch: "amd64"
+          java-version: "17"
+          distribution: "graalvm"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - run: java -version
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4.36.2
@@ -129,15 +129,13 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup GraalVM
-        uses: DeLaGuardo/setup-graalvm@5.0
+        uses: graalvm/setup-graalvm@v1
         with:
-          graalvm: "22.2.0"
-          java: "java17"
-          arch: "amd64"
+          java-version: "17"
+          distribution: "graalvm"
+          components: "native-image"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - run: java -version
-      - name: setup-native-image
-        run: |
-          gu install native-image
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4.36.2
         with:
@@ -244,15 +242,13 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup GraalVM
-        uses: DeLaGuardo/setup-graalvm@5.0
+        uses: graalvm/setup-graalvm@v1
         with:
-          graalvm: "22.2.0"
-          java: "java17"
-          arch: "amd64"
+          java-version: "17"
+          distribution: "graalvm"
+          components: "native-image"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - run: java -version
-      - name: setup-native-image
-        run: |
-          gu install native-image
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4.36.2
         with:


### PR DESCRIPTION
## 概要

Java CI の `Setup GraalVM` を非公式の `DeLaGuardo/setup-graalvm@5.0`（GraalVM 22.2.0 / JDK 17.0.4・2022年8月）から、公式 `graalvm/setup-graalvm@v1` へ移行します。

cgroup v2 の GitHub ランナー上では、この古い JDK で `@QuarkusTest` 起動時に既知の JDK バグが発生していました:

```
NullPointerException: Cannot invoke
"jdk.internal.platform.CgroupInfo.getMountPoint()" because "anyController" is null
```

## 変更内容

- 3ジョブ（`build-init` / `build-jvm` / `build-native`）すべての `Setup GraalVM` を `graalvm/setup-graalvm@v1` に変更
- `java-version: "17"` を指定（17系の最新パッチ＝NPE 修正済み。`maven.compiler.target=17` と整合し変更を最小化）
- `distribution: "graalvm"` を指定
- native-image は新 GraalVM で `gu install` が廃止されているため、`components: "native-image"` で取得するよう変更し、旧 `gu install native-image` ステップを削除

## 関連

- Closes #4057
- 前提: #4052（JaCoCo 二重計装の修正）— 二重計装クラッシュ解消後に表面化したのが本 NPE です。両方そろうことで Java CI が緑になる想定です。

## 確認

- [x] YAML 構文チェック（`yaml.safe_load`）OK
- [ ] CI で `@QuarkusTest` が NPE なく起動すること
- [ ] native-image ビルド（`build-native`）が `components` 経由で問題なく動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)