### PR TITLE
fix(metrics): migrate from SmallRye Metrics to Micrometer

### DIFF
--- a/application/jaxrs-activemq-quarkus/src/main/java/webapp/tier/resource/ActiveMqResource.java
+++ b/application/jaxrs-activemq-quarkus/src/main/java/webapp/tier/resource/ActiveMqResource.java
@@ -10,9 +10,8 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 import org.eclipse.microprofile.faulttolerance.Retry;
-import org.eclipse.microprofile.metrics.MetricUnits;
-import org.eclipse.microprofile.metrics.annotation.Counted;
-import org.eclipse.microprofile.metrics.annotation.Timed;
+import io.micrometer.core.annotation.Counted;
+import io.micrometer.core.annotation.Timed;
 
 import webapp.tier.service.ActiveMqService;
 
@@ -26,8 +25,8 @@ public class ActiveMqResource {
 
 	@POST
 	@Path("/put")
-	@Counted(name = "performedChecks_put", description = "How many primality checks have been performed.")
-	@Timed(name = "checksTimer_put", description = "A measure of how long it takes to perform the primality test.", unit = MetricUnits.MILLISECONDS)
+	@Counted(value = "performedChecks_put", description = "How many primality checks have been performed.")
+	@Timed(value = "checksTimer_put", description = "A measure of how long it takes to perform the primality test.")
 	public Response putcache() {
 		try {
 			return Response.ok().entity(svc.putMsg().getFullmsg()).build();
@@ -39,8 +38,8 @@ public class ActiveMqResource {
 	@GET
 	@Path("/get")
 	@Retry(maxRetries = 3)
-	@Counted(name = "performedChecks_get", description = "How many primality checks have been performed.")
-	@Timed(name = "checksTimer_get", description = "A measure of how long it takes to perform the primality test.", unit = MetricUnits.MILLISECONDS)
+	@Counted(value = "performedChecks_get", description = "How many primality checks have been performed.")
+	@Timed(value = "checksTimer_get", description = "A measure of how long it takes to perform the primality test.")
 	public Response getcache() {
 		try {
 			return Response.ok().entity(svc.getMsg().getFullmsg()).build();
@@ -51,8 +50,8 @@ public class ActiveMqResource {
 
 	@POST
 	@Path("/publish")
-	@Counted(name = "performedChecks_publish", description = "How many primality checks have been performed.")
-	@Timed(name = "checksTimer_publish", description = "A measure of how long it takes to perform the primality test.", unit = MetricUnits.MILLISECONDS)
+	@Counted(value = "performedChecks_publish", description = "How many primality checks have been performed.")
+	@Timed(value = "checksTimer_publish", description = "A measure of how long it takes to perform the primality test.")
 	public Response publish() {
 		try {
 			return Response.ok().entity(svc.publishMsg().getFullmsg()).build();

--- a/application/jaxrs-cassandra-quarkus/src/main/java/webapp/tier/resource/CassandraResource.java
+++ b/application/jaxrs-cassandra-quarkus/src/main/java/webapp/tier/resource/CassandraResource.java
@@ -12,9 +12,8 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 import org.eclipse.microprofile.faulttolerance.Retry;
-import org.eclipse.microprofile.metrics.MetricUnits;
-import org.eclipse.microprofile.metrics.annotation.Counted;
-import org.eclipse.microprofile.metrics.annotation.Timed;
+import io.micrometer.core.annotation.Counted;
+import io.micrometer.core.annotation.Timed;
 
 import webapp.tier.service.CassandraService;
 import webapp.tier.bean.MsgBean;
@@ -29,8 +28,8 @@ public class CassandraResource {
 
 	@POST
 	@Path("/insert")
-	@Counted(name = "performedChecks_insert", description = "How many primality checks have been performed.")
-	@Timed(name = "checksTimer_insert", description = "A measure of how long it takes to perform the primality test.", unit = MetricUnits.MILLISECONDS)
+	@Counted(value = "performedChecks_insert", description = "How many primality checks have been performed.")
+	@Timed(value = "checksTimer_insert", description = "A measure of how long it takes to perform the primality test.")
 	public Response insert() {
 		try {
 			return Response.ok().entity(svc.insertMsg().getFullmsg()).build();
@@ -42,8 +41,8 @@ public class CassandraResource {
 	@GET
 	@Path("/select")
 	@Retry(maxRetries = 3)
-	@Counted(name = "performedChecks_select", description = "How many primality checks have been performed.")
-	@Timed(name = "checksTimer_select", description = "A measure of how long it takes to perform the primality test.", unit = MetricUnits.MILLISECONDS)
+	@Counted(value = "performedChecks_select", description = "How many primality checks have been performed.")
+	@Timed(value = "checksTimer_select", description = "A measure of how long it takes to perform the primality test.")
 	public Response select() {
 		try {
 			String result = svc.selectMsg().stream()
@@ -57,8 +56,8 @@ public class CassandraResource {
 
 	@POST
 	@Path("/delete")
-	@Counted(name = "performedChecks_delete", description = "How many primality checks have been performed.")
-	@Timed(name = "checksTimer_delete", description = "A measure of how long it takes to perform the primality test.", unit = MetricUnits.MILLISECONDS)
+	@Counted(value = "performedChecks_delete", description = "How many primality checks have been performed.")
+	@Timed(value = "checksTimer_delete", description = "A measure of how long it takes to perform the primality test.")
 	public Response delete() {
 		try {
 			return Response.ok().entity(svc.deleteMsg()).build();

--- a/application/jaxrs-hazelcast-quarkus/src/main/java/webapp/tier/resource/HazelcastResource.java
+++ b/application/jaxrs-hazelcast-quarkus/src/main/java/webapp/tier/resource/HazelcastResource.java
@@ -13,9 +13,8 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 import org.eclipse.microprofile.faulttolerance.Retry;
-import org.eclipse.microprofile.metrics.MetricUnits;
-import org.eclipse.microprofile.metrics.annotation.Counted;
-import org.eclipse.microprofile.metrics.annotation.Timed;
+import io.micrometer.core.annotation.Counted;
+import io.micrometer.core.annotation.Timed;
 
 import webapp.tier.service.HazelcastCacheService;
 import webapp.tier.service.HazelcastMqService;
@@ -36,8 +35,8 @@ public class HazelcastResource {
 
 	@POST
 	@Path("/setcache")
-	@Counted(name = "performedChecks_setcache", description = "How many primality checks have been performed.")
-	@Timed(name = "checksTimer_setcache", description = "A measure of how long it takes to perform the primality test.", unit = MetricUnits.MILLISECONDS)
+	@Counted(value = "performedChecks_setcache", description = "How many primality checks have been performed.")
+	@Timed(value = "checksTimer_setcache", description = "A measure of how long it takes to perform the primality test.")
 	public Response putcache() {
 		try {
 			return Response.ok().entity(cachesvc.setMsg(HazelcastService.getInstance()))
@@ -51,8 +50,8 @@ public class HazelcastResource {
 	@GET
 	@Path("/getcache")
 	@Retry(maxRetries = 3)
-	@Counted(name = "performedChecks_getcache", description = "How many primality checks have been performed.")
-	@Timed(name = "checksTimer_getcache", description = "A measure of how long it takes to perform the primality test.", unit = MetricUnits.MILLISECONDS)
+	@Counted(value = "performedChecks_getcache", description = "How many primality checks have been performed.")
+	@Timed(value = "checksTimer_getcache", description = "A measure of how long it takes to perform the primality test.")
 	public Response getcache() {
 		try {
 			return Response.ok()
@@ -66,8 +65,8 @@ public class HazelcastResource {
 
 	@POST
 	@Path("/putqueue")
-	@Counted(name = "performedChecks_putqueue", description = "How many primality checks have been performed.")
-	@Timed(name = "checksTimer_putqueue", description = "A measure of how long it takes to perform the primality test.", unit = MetricUnits.MILLISECONDS)
+	@Counted(value = "performedChecks_putqueue", description = "How many primality checks have been performed.")
+	@Timed(value = "checksTimer_putqueue", description = "A measure of how long it takes to perform the primality test.")
 	public Response putqueue() {
 		try {
 			return Response.ok().entity(mqsvc.putMsg(HazelcastService.getInstance()))
@@ -81,8 +80,8 @@ public class HazelcastResource {
 	@GET
 	@Path("/getqueue")
 	@Retry(maxRetries = 3)
-	@Counted(name = "performedChecks_getqueue", description = "How many primality checks have been performed.")
-	@Timed(name = "checksTimer_getqueue", description = "A measure of how long it takes to perform the primality test.", unit = MetricUnits.MILLISECONDS)
+	@Counted(value = "performedChecks_getqueue", description = "How many primality checks have been performed.")
+	@Timed(value = "checksTimer_getqueue", description = "A measure of how long it takes to perform the primality test.")
 	public Response getqueue() {
 		try {
 			return Response.ok().entity(mqsvc.getMsg(HazelcastService.getInstance()))
@@ -95,8 +94,8 @@ public class HazelcastResource {
 
 	@POST
 	@Path("/publish")
-	@Counted(name = "performedChecks_publish", description = "How many primality checks have been performed.")
-	@Timed(name = "checksTimer_publish", description = "A measure of how long it takes to perform the primality test.", unit = MetricUnits.MILLISECONDS)
+	@Counted(value = "performedChecks_publish", description = "How many primality checks have been performed.")
+	@Timed(value = "checksTimer_publish", description = "A measure of how long it takes to perform the primality test.")
 	public Response publish() {
 		try {
 			return Response.ok().entity(mqsvc.publishMsg(HazelcastService.getInstance()))

--- a/application/jaxrs-memcached-quarkus/src/main/java/webapp/tier/resource/MemcachedResource.java
+++ b/application/jaxrs-memcached-quarkus/src/main/java/webapp/tier/resource/MemcachedResource.java
@@ -13,9 +13,8 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 import org.eclipse.microprofile.faulttolerance.Retry;
-import org.eclipse.microprofile.metrics.MetricUnits;
-import org.eclipse.microprofile.metrics.annotation.Counted;
-import org.eclipse.microprofile.metrics.annotation.Timed;
+import io.micrometer.core.annotation.Counted;
+import io.micrometer.core.annotation.Timed;
 
 import webapp.tier.service.MemcachedService;
 
@@ -31,8 +30,8 @@ public class MemcachedResource {
 
 	@POST
 	@Path("/set")
-	@Counted(name = "performedChecks_set", description = "How many primality checks have been performed.")
-	@Timed(name = "checksTimer_set", description = "A measure of how long it takes to perform the primality test.", unit = MetricUnits.MILLISECONDS)
+	@Counted(value = "performedChecks_set", description = "How many primality checks have been performed.")
+	@Timed(value = "checksTimer_set", description = "A measure of how long it takes to perform the primality test.")
 	public Response set() {
 		try {
 			return Response.ok().entity(svc.setMsg(svc.createMemCachedClient()).getFullmsg()).build();
@@ -45,8 +44,8 @@ public class MemcachedResource {
 	@GET
 	@Path("/get")
 	@Retry(maxRetries = 3)
-	@Counted(name = "performedChecks_get", description = "How many primality checks have been performed.")
-	@Timed(name = "checksTimer_get", description = "A measure of how long it takes to perform the primality test.", unit = MetricUnits.MILLISECONDS)
+	@Counted(value = "performedChecks_get", description = "How many primality checks have been performed.")
+	@Timed(value = "checksTimer_get", description = "A measure of how long it takes to perform the primality test.")
 	public Response get() {
 		try {
 			return Response.ok().entity(svc.getMsg(svc.createMemCachedClient()).getFullmsg()).build();

--- a/application/jaxrs-mongodb-quarkus/src/main/java/webapp/tier/resource/MongodbResource.java
+++ b/application/jaxrs-mongodb-quarkus/src/main/java/webapp/tier/resource/MongodbResource.java
@@ -15,9 +15,8 @@ import jakarta.ws.rs.core.Response;
 
 import org.bson.Document;
 import org.eclipse.microprofile.faulttolerance.Retry;
-import org.eclipse.microprofile.metrics.MetricUnits;
-import org.eclipse.microprofile.metrics.annotation.Counted;
-import org.eclipse.microprofile.metrics.annotation.Timed;
+import io.micrometer.core.annotation.Counted;
+import io.micrometer.core.annotation.Timed;
 
 import com.mongodb.client.MongoCollection;
 
@@ -36,8 +35,8 @@ public class MongodbResource {
 
 	@POST
 	@Path("/insert")
-	@Counted(name = "performedChecks_insert", description = "How many primality checks have been performed.")
-	@Timed(name = "checksTimer_insert", description = "A measure of how long it takes to perform the primality test.", unit = MetricUnits.MILLISECONDS)
+	@Counted(value = "performedChecks_insert", description = "How many primality checks have been performed.")
+	@Timed(value = "checksTimer_insert", description = "A measure of how long it takes to perform the primality test.")
 	public Response insert() {
 		try {
 			MongoCollection<Document> collection = mongosvc.getCollection();
@@ -51,8 +50,8 @@ public class MongodbResource {
 	@GET
 	@Path("/select")
 	@Retry(maxRetries = 3)
-	@Counted(name = "performedChecks_select", description = "How many primality checks have been performed.")
-	@Timed(name = "checksTimer_select", description = "A measure of how long it takes to perform the primality test.", unit = MetricUnits.MILLISECONDS)
+	@Counted(value = "performedChecks_select", description = "How many primality checks have been performed.")
+	@Timed(value = "checksTimer_select", description = "A measure of how long it takes to perform the primality test.")
 	public Response select() {
 		try {
 			MongoCollection<Document> collection = mongosvc.getCollection();
@@ -68,8 +67,8 @@ public class MongodbResource {
 
 	@POST
 	@Path("/delete")
-	@Counted(name = "performedChecks_delete", description = "How many primality checks have been performed.")
-	@Timed(name = "checksTimer_delete", description = "A measure of how long it takes to perform the primality test.", unit = MetricUnits.MILLISECONDS)
+	@Counted(value = "performedChecks_delete", description = "How many primality checks have been performed.")
+	@Timed(value = "checksTimer_delete", description = "A measure of how long it takes to perform the primality test.")
 	public Response delete() {
 		try {
 			MongoCollection<Document> collection = mongosvc.getCollection();

--- a/application/jaxrs-mysql-quarkus/src/main/java/webapp/tier/resource/MysqlResource.java
+++ b/application/jaxrs-mysql-quarkus/src/main/java/webapp/tier/resource/MysqlResource.java
@@ -16,9 +16,8 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 import org.eclipse.microprofile.faulttolerance.Retry;
-import org.eclipse.microprofile.metrics.MetricUnits;
-import org.eclipse.microprofile.metrics.annotation.Counted;
-import org.eclipse.microprofile.metrics.annotation.Timed;
+import io.micrometer.core.annotation.Counted;
+import io.micrometer.core.annotation.Timed;
 
 import webapp.tier.service.MysqlService;
 import webapp.tier.bean.MsgBean;
@@ -35,8 +34,8 @@ public class MysqlResource {
 
 	@POST
 	@Path("/insert")
-	@Counted(name = "performedChecks_insert", description = "How many primality checks have been performed.")
-	@Timed(name = "checksTimer_insert", description = "A measure of how long it takes to perform the primality test.", unit = MetricUnits.MILLISECONDS)
+	@Counted(value = "performedChecks_insert", description = "How many primality checks have been performed.")
+	@Timed(value = "checksTimer_insert", description = "A measure of how long it takes to perform the primality test.")
 	public Response insert() {
 		try {
 			return Response.ok().entity(mysqlsvc.insertMsg().getFullmsg()).build();
@@ -49,8 +48,8 @@ public class MysqlResource {
 	@GET
 	@Path("/select")
 	@Retry(maxRetries = 3)
-	@Counted(name = "performedChecks_select", description = "How many primality checks have been performed.")
-	@Timed(name = "checksTimer_select", description = "A measure of how long it takes to perform the primality test.", unit = MetricUnits.MILLISECONDS)
+	@Counted(value = "performedChecks_select", description = "How many primality checks have been performed.")
+	@Timed(value = "checksTimer_select", description = "A measure of how long it takes to perform the primality test.")
 	public Response select() {
 		try {
 			String result = mysqlsvc.selectMsg().stream()
@@ -65,8 +64,8 @@ public class MysqlResource {
 
 	@POST
 	@Path("/delete")
-	@Counted(name = "performedChecks_delete", description = "How many primality checks have been performed.")
-	@Timed(name = "checksTimer_delete", description = "A measure of how long it takes to perform the primality test.", unit = MetricUnits.MILLISECONDS)
+	@Counted(value = "performedChecks_delete", description = "How many primality checks have been performed.")
+	@Timed(value = "checksTimer_delete", description = "A measure of how long it takes to perform the primality test.")
 	public Response delete() {
 		try {
 			return Response.ok().entity(mysqlsvc.deleteMsg()).build();

--- a/application/jaxrs-postgres-quarkus/src/main/java/webapp/tier/resource/PostgresResource.java
+++ b/application/jaxrs-postgres-quarkus/src/main/java/webapp/tier/resource/PostgresResource.java
@@ -16,9 +16,8 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 import org.eclipse.microprofile.faulttolerance.Retry;
-import org.eclipse.microprofile.metrics.MetricUnits;
-import org.eclipse.microprofile.metrics.annotation.Counted;
-import org.eclipse.microprofile.metrics.annotation.Timed;
+import io.micrometer.core.annotation.Counted;
+import io.micrometer.core.annotation.Timed;
 
 import webapp.tier.service.PostgresService;
 import webapp.tier.bean.MsgBean;
@@ -35,8 +34,8 @@ public class PostgresResource {
 
 	@POST
 	@Path("/insert")
-	@Counted(name = "performedChecks_insert", description = "How many primality checks have been performed.")
-	@Timed(name = "checksTimer_insert", description = "A measure of how long it takes to perform the primality test.", unit = MetricUnits.MILLISECONDS)
+	@Counted(value = "performedChecks_insert", description = "How many primality checks have been performed.")
+	@Timed(value = "checksTimer_insert", description = "A measure of how long it takes to perform the primality test.")
 	public Response insert() {
 		try {
 			return Response.ok().entity(posgressvc.insertMsg().getFullmsg()).build();
@@ -49,8 +48,8 @@ public class PostgresResource {
 	@GET
 	@Path("/select")
 	@Retry(maxRetries = 3)
-	@Counted(name = "performedChecks_select", description = "How many primality checks have been performed.")
-	@Timed(name = "checksTimer_select", description = "A measure of how long it takes to perform the primality test.", unit = MetricUnits.MILLISECONDS)
+	@Counted(value = "performedChecks_select", description = "How many primality checks have been performed.")
+	@Timed(value = "checksTimer_select", description = "A measure of how long it takes to perform the primality test.")
 	public Response select() {
 		try {
 			String result = posgressvc.selectMsg().stream()
@@ -65,8 +64,8 @@ public class PostgresResource {
 
 	@POST
 	@Path("/delete")
-	@Counted(name = "performedChecks_delete", description = "How many primality checks have been performed.")
-	@Timed(name = "checksTimer_delete", description = "A measure of how long it takes to perform the primality test.", unit = MetricUnits.MILLISECONDS)
+	@Counted(value = "performedChecks_delete", description = "How many primality checks have been performed.")
+	@Timed(value = "checksTimer_delete", description = "A measure of how long it takes to perform the primality test.")
 	public Response delete() {
 		try {
 			return Response.ok().entity(posgressvc.deleteMsg()).build();

--- a/application/jaxrs-rabbitmq-quarkus/src/main/java/webapp/tier/resource/RabbitmqResource.java
+++ b/application/jaxrs-rabbitmq-quarkus/src/main/java/webapp/tier/resource/RabbitmqResource.java
@@ -11,9 +11,8 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-import org.eclipse.microprofile.metrics.MetricUnits;
-import org.eclipse.microprofile.metrics.annotation.Counted;
-import org.eclipse.microprofile.metrics.annotation.Timed;
+import io.micrometer.core.annotation.Counted;
+import io.micrometer.core.annotation.Timed;
 
 import webapp.tier.service.RabbitmqService;
 
@@ -29,8 +28,8 @@ public class RabbitmqResource {
 
 	@POST
 	@Path("/publish")
-	@Counted(name = "performedChecks_publish", description = "How many primality checks have been performed.")
-	@Timed(name = "checksTimer_publish", description = "A measure of how long it takes to perform the primality test.", unit = MetricUnits.MILLISECONDS)
+	@Counted(value = "performedChecks_publish", description = "How many primality checks have been performed.")
+	@Timed(value = "checksTimer_publish", description = "A measure of how long it takes to perform the primality test.")
 	public Response publish() {
 		try {
 			return Response.ok().entity(svc.publishMsg().getFullmsg()).build();

--- a/application/parent-pom/pom.xml
+++ b/application/parent-pom/pom.xml
@@ -106,9 +106,16 @@
 			<groupId>io.quarkus</groupId>
 			<artifactId>quarkus-opentelemetry</artifactId>
 		</dependency>
+		<!--
+			SmallRye Metrics (MicroProfile Metrics) was deprecated and removed
+			from the Quarkus platform BOM. Micrometer is the supported metrics
+			stack, so we use quarkus-micrometer; the @Counted/@Timed annotations
+			are migrated from org.eclipse.microprofile.metrics.annotation.* to
+			io.micrometer.core.annotation.*.
+		-->
 		<dependency>
 			<groupId>io.quarkus</groupId>
-			<artifactId>quarkus-smallrye-metrics</artifactId>
+			<artifactId>quarkus-micrometer</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>io.quarkus</groupId>

--- a/application/randompublish-quarkus/src/main/java/webapp/tier/resource/RandomResource.java
+++ b/application/randompublish-quarkus/src/main/java/webapp/tier/resource/RandomResource.java
@@ -9,9 +9,8 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-import org.eclipse.microprofile.metrics.MetricUnits;
-import org.eclipse.microprofile.metrics.annotation.Counted;
-import org.eclipse.microprofile.metrics.annotation.Timed;
+import io.micrometer.core.annotation.Counted;
+import io.micrometer.core.annotation.Timed;
 
 import webapp.tier.service.RandomService;
 
@@ -25,8 +24,8 @@ public class RandomResource {
 	RandomService randomsvc;
 
 	@GET
-	@Counted(name = "performedChecks", description = "How many primality checks have been performed.")
-	@Timed(name = "checksTimer", description = "A measure of how long it takes to perform the primality test.", unit = MetricUnits.MILLISECONDS)
+	@Counted(value = "performedChecks", description = "How many primality checks have been performed.")
+	@Timed(value = "checksTimer", description = "A measure of how long it takes to perform the primality test.")
 	public Response random() {
 		try {
 			return Response.ok().entity(randomsvc.deliverrandom(randomsvc.getNum(6)))


### PR DESCRIPTION
## 概要

Quarkus 3.37 で `quarkus-smallrye-metrics` が platform BOM から削除され、`build-init` が version 欠落で失敗していた問題を修正します。SmallRye Metrics（MicroProfile Metrics）から Micrometer へ移行します。

```
[ERROR] 'dependencies.dependency.version' for io.quarkus:quarkus-smallrye-metrics:jar is missing.
```

## 変更内容

- parent-pom: `quarkus-smallrye-metrics` → `quarkus-micrometer`
- metrics アノテーションを使う 9 モジュールを Micrometer へ移行:
  - `org.eclipse.microprofile.metrics.annotation.Counted/Timed` → `io.micrometer.core.annotation.Counted/Timed`
  - `MetricUnits` import 削除、`@Timed` の `unit` 属性除去（Micrometer の Timer は常に時間ベース）
  - `@Counted(name=...)` / `@Timed(name=...)` → `value=...`

対象: jaxrs-activemq / cassandra / hazelcast / memcached / mongodb / mysql / postgres / rabbitmq / randompublish

## 確認

- [x] parent-pom install 成功（version 欠落解消）
- [x] jaxrs-activemq-quarkus でローカル `test` 成功（`Installed features: [..., micrometer, ...]`・16テスト緑）
- [ ] CI で build-init / build-jvm / build-native が緑

## 背景

直前の PR #4066 で Java CI を緑化した後、master 側の #4059（Quarkus 3.37 更新）と合流して顕在化した、プラットフォーム追従漏れの最後の1件です。

Closes #4086

🤖 Generated with [Claude Code](https://claude.com/claude-code)