### PR TITLE
fix(ci): repair mysql-exporter config for mysqld-exporter v0.19.0

### DIFF
--- a/.github/workflows/kind-quarkus-ci.yml
+++ b/.github/workflows/kind-quarkus-ci.yml
@@ -77,7 +77,7 @@ jobs:
         if: always()
         run: |
           kubectl describe po $(kubectl get pods | awk '{print $1}' | grep -E ^mysql)
-          kubectl logs $(kubectl get pods | awk '{print $1}' | grep -E ^mysql) -c mysql
+          kubectl logs $(kubectl get pods | awk '{print $1}' | grep -E ^mysql) --all-containers=true --prefix=true
       - name: check log rabbitmq
         if: always()
         run: |

--- a/.github/workflows/minikube-quarkus-ci.yml
+++ b/.github/workflows/minikube-quarkus-ci.yml
@@ -91,6 +91,16 @@ jobs:
         run: |
           kubectl -n monitoring describe po $(kubectl get pods -n monitoring | awk '{print $1}' | grep postmannewman-quarkus)
           kubectl -n monitoring logs $(kubectl get pods -n monitoring | awk '{print $1}' | grep postmannewman-quarkus)
+      - name: check log mysql
+        if: always()
+        run: |
+          kubectl describe po $(kubectl get pods | awk '{print $1}' | grep -E ^mysql)
+          kubectl logs $(kubectl get pods | awk '{print $1}' | grep -E ^mysql) --all-containers=true --prefix=true
+      - name: check log nginx
+        if: always()
+        run: |
+          kubectl describe po $(kubectl get pods | awk '{print $1}' | grep -E ^nginx)
+          kubectl logs $(kubectl get pods | awk '{print $1}' | grep -E ^nginx) --all-containers=true --prefix=true
       - name: check status
         if: always()
         run: |

--- a/kubernetes/mysql/mysql-deployment.yaml
+++ b/kubernetes/mysql/mysql-deployment.yaml
@@ -53,10 +53,15 @@ spec:
               mountPath: /var/lib/mysql
         - name: mysql-exporter
           image: prom/mysqld-exporter:v0.19.0
+          args:
+            - --mysqld.address=localhost:3306
+            - --mysqld.username=root
           ports:
             - containerPort: 9104
           env:
-            - name: DATA_SOURCE_NAME
+            # DATA_SOURCE_NAME was removed in mysqld-exporter v0.15.0.
+            # Connection is now configured via --mysqld.* flags and this env var.
+            - name: MYSQLD_EXPORTER_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: mysql-secret

--- a/kubernetes/mysql/mysql-secret.yaml
+++ b/kubernetes/mysql/mysql-secret.yaml
@@ -5,4 +5,4 @@ metadata:
 type: Opaque
 data:
   mysql-root-password: c3VwZXJzZWNyZXQ=
-  mysql-exporter-password: cm9vdDpzdXBlcnNlY3JldEAobG9jYWxob3N0OjMzMDYpLw==
+  mysql-exporter-password: c3VwZXJzZWNyZXQ=


### PR DESCRIPTION
## 概要
`minikube-quarkus-ci` / `kind-quarkus-ci` が恒常的に失敗していた問題を修正する。

## 原因
e2e ジョブ `postmannewman-quarkus` が30分タイムアウト → master で23回連続failure（成功実績なし）。
直接原因は **mysql pod が `1/2` (CrashLoopBackOff)** で Ready にならないこと。落ちているのは sidecar の `mysql-exporter`。

- `prom/mysqld-exporter` は **v0.15.0 で `DATA_SOURCE_NAME` 環境変数を廃止**。
- 現行 v0.19.0 にDSN文字列を渡しても解釈できず起動失敗していた。

## 変更
- `mysql-deployment.yaml`: exporter の接続設定を `--mysqld.address` / `--mysqld.username` フラグ + `MYSQLD_EXPORTER_PASSWORD` 環境変数へ移行。
- `mysql-secret.yaml`: `mysql-exporter-password` をDSN文字列 → 平文パスワードへ修正。
- `minikube-quarkus-ci.yml` / `kind-quarkus-ci.yml`: mysql/nginx pod の **全コンテナ** describe+logs 診断ステップを追加（従来 sidecar ログ未採取で原因特定が困難だったため）。

## 確認方法
本PRは両 quarkus CI ワークフローファイルを変更しているため、PR上で両CIが実行される。mysql pod が `2/2` Ready になり e2e ジョブが完走することを確認する。

## 補足
nginx pod も `1/2` で CrashLoop しているが（exporter の `SCRAPE_URI` がポート80指定、nginx本体は8080）、ログ未採取のため本PRの診断ステップ追加後に確実な原因を確認してから別PRで対応する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)