### PR TITLE
fix(ci): correct docker image push condition in docker-image-ci

### DIFF
--- a/.github/workflows/docker-image-ci.yml
+++ b/.github/workflows/docker-image-ci.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: setup docker push actions
         run: |
-          if [[ github.event_name == 'push' ]]; then
+          if [[ "${{ github.event_name }}" == 'push' ]]; then
             echo "PUSH=true" >> $GITHUB_ENV
           else
             echo "PUSH=false" >> $GITHUB_ENV


### PR DESCRIPTION
## 概要
`docker-image-ci` が **master push 時にもイメージを DockerHub へ push できていなかった**問題を修正する。これが quarkus CI の nginx CrashLoop（恒常fail）の根本原因。

## 根本原因
PUSH 判定の bash 条件式に `${{ }}` 補間が欠落していた：

```bash
if [[ github.event_name == 'push' ]]; then   # リテラル文字列比較 → 常に false
```

このため `PUSH=false` に固定され、2023-02以降 `yurak/*:latest` が一度も push されていなかった。commit `675e2527`（2023-02-06）で混入。

## 実証（PR #4088 で追加した診断ログより）
クラスタ稼働イメージが Dockerfile の指定と乖離：

| image | Dockerfile指定 | 実際の稼働版 |
|-------|------|------|
| nginx | `nginx:1.31` | `nginx/1.23.3` |
| mysql | `mysql:9.7.1` | `MySQL 8.0.32` |

nginx は `listen 80→8080`（2023-02）より**前の旧イメージ**が動いており、80番待受のまま。liveness `tcpSocket:8080` が `connection refused` → CrashLoopBackOff（13回再起動）→ e2e タイムアウト。

## 変更
`"${{ github.event_name }}" == 'push'` に修正。これで master push 時に各イメージが再ビルド・push され、最新の Dockerfile/設定が反映される。

## 確認方法
マージ後、master の `docker-image-ci` で実際に push されること、続く quarkus CI で nginx pod が `2/2` Ready になることを確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)