### PR TITLE
fix(redis): eagerly init RedisService to stop testGet deadlock

### DIFF
--- a/application/jaxrs-redis-quarkus/src/main/java/webapp/tier/service/RedisService.java
+++ b/application/jaxrs-redis-quarkus/src/main/java/webapp/tier/service/RedisService.java
@@ -17,10 +17,22 @@ import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.datasource.keys.KeyCommands;
 import io.quarkus.redis.datasource.pubsub.PubSubCommands;
 import io.quarkus.redis.datasource.value.ValueCommands;
+import io.quarkus.runtime.Startup;
 import webapp.tier.bean.MsgBean;
 import webapp.tier.util.CreateId;
 import webapp.tier.util.MsgUtils;
 
+/**
+ * Eagerly initialized at startup via {@link Startup}. The constructor performs
+ * a blocking {@code pub.subscribe(...)}; if the bean is instead created lazily
+ * on the first request (a worker thread), that blocking subscribe can deadlock
+ * against the Redis client event loop and time out
+ * ({@code io.smallrye.mutiny.TimeoutException}), which surfaced as the flaky
+ * RedisResourceTest.testGet failure in CI. Initializing at startup (as the
+ * consumer-redis RedisDeliverSubscriber already does) runs the subscribe before
+ * any request is served and avoids the deadlock.
+ */
+@Startup
 @ApplicationScoped
 public class RedisService implements Consumer<RedisNotification> {
 

--- a/application/jaxrs-redis-quarkus/src/test/java/webapp/tier/resource/RedisResourceTest.java
+++ b/application/jaxrs-redis-quarkus/src/test/java/webapp/tier/resource/RedisResourceTest.java
@@ -41,7 +41,6 @@ class RedisResourceTest {
 				.body(containsString(message));
 	}
 
-	// TODO fix: MsgBean init error
 	@Test
 	void testGet() {
 		given()
@@ -55,7 +54,7 @@ class RedisResourceTest {
 				.get("/quarkus/redis/get")
 				.then()
 				.statusCode(200)
-				.body(containsString("MsgBean init error"));
+				.body(containsString(message));
 	}
 
 	@Test


### PR DESCRIPTION
## 背景

全 Java CI run（および全 Renovate PR）をブロックしていた `build-jvm (jaxrs-redis-quarkus)` の失敗を恒久修正します。

## 真因

`RedisResourceTest.testGet` の失敗は **フレーキー（コンテナ起動レース）ではなく再現性のある実バグ** でした。

- `RedisService` は `@ApplicationScoped` で、コンストラクタ内で **ブロッキングな `pub.subscribe()`** を実行している
- bean が最初のリクエスト時（worker thread 上）に遅延生成されると、この subscribe が Redis クライアントの event loop とデッドロックし、`io.smallrye.mutiny.TimeoutException` → HTTP 500 になる
- ログ: `WARN [RedisStandaloneConnection] No handler waiting for message: [subscribe, pubsub, 1]` → 10〜30秒後にタイムアウト
- **ローカルで 100% 再現**。CI で「時々通る」のは、別テストが先に bean 初期化を誘発する実行順序依存のため
- コマンドタイムアウト延長では直らない（30s に延ばすと 30s 待って失敗するだけ）と実証済み

## 修正

1. **プロダクト**: `RedisService` に `@Startup` を付与。起動時に subscribe を実行し、リクエスト処理前に完了させてデッドロックを回避。動作実績のある consumer-redis の `RedisDeliverSubscriber`（既に `@Startup`）と同じパターン。
2. **テスト**: `testGet` の壊れたアサーションを修正。`statusCode(200)` を期待しつつ body に `MsgBean` の初期値 `"MsgBean init error"` を期待していた矛盾を、put → get で返る実メッセージ（`common.message`）の検証に修正し、stale な TODO コメントを削除。

## 検証

ローカル（podman + Redis Dev Services, JDK 21）:
- 修正前: testGet が 100% デッドロック（20〜30s タイムアウト）
- 修正後: 全 12 テスト green、testGet は約 0.3s で安定通過、3 回連続 BUILD SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)