### PR TITLE
ci(quarkus): add pod diagnostics for all DB components

### DIFF
--- a/.github/workflows/kind-quarkus-ci.yml
+++ b/.github/workflows/kind-quarkus-ci.yml
@@ -83,6 +83,36 @@ jobs:
         run: |
           kubectl describe po $(kubectl get pods | awk '{print $1}' | grep -E ^rabbitmq)
           kubectl logs $(kubectl get pods | awk '{print $1}' | grep -E ^rabbitmq) -c rabbitmq
+      - name: check log nginx
+        if: always()
+        run: |
+          kubectl describe po $(kubectl get pods | awk '{print $1}' | grep -E ^nginx)
+          kubectl logs $(kubectl get pods | awk '{print $1}' | grep -E ^nginx) --all-containers=true --prefix=true
+      - name: check log postgres
+        if: always()
+        run: |
+          kubectl describe po $(kubectl get pods | awk '{print $1}' | grep -E ^postgres)
+          kubectl logs $(kubectl get pods | awk '{print $1}' | grep -E ^postgres) --all-containers=true --prefix=true
+      - name: check log mongodb
+        if: always()
+        run: |
+          kubectl describe po $(kubectl get pods | awk '{print $1}' | grep -E ^mongodb)
+          kubectl logs $(kubectl get pods | awk '{print $1}' | grep -E ^mongodb) --all-containers=true --prefix=true
+      - name: check log cassandra
+        if: always()
+        run: |
+          kubectl describe po $(kubectl get pods | awk '{print $1}' | grep -E ^cassandra)
+          kubectl logs $(kubectl get pods | awk '{print $1}' | grep -E ^cassandra) --all-containers=true --prefix=true
+      - name: check log kafka
+        if: always()
+        run: |
+          kubectl describe po $(kubectl get pods | awk '{print $1}' | grep -E ^kafka)
+          kubectl logs $(kubectl get pods | awk '{print $1}' | grep -E ^kafka) --all-containers=true --prefix=true
+      - name: check log zookeeper
+        if: always()
+        run: |
+          kubectl describe po $(kubectl get pods | awk '{print $1}' | grep -E ^zookeeper)
+          kubectl logs $(kubectl get pods | awk '{print $1}' | grep -E ^zookeeper) --all-containers=true --prefix=true
       - name: check log ingress
         if: always()
         run: |

--- a/.github/workflows/minikube-quarkus-ci.yml
+++ b/.github/workflows/minikube-quarkus-ci.yml
@@ -101,6 +101,26 @@ jobs:
         run: |
           kubectl describe po $(kubectl get pods | awk '{print $1}' | grep -E ^nginx)
           kubectl logs $(kubectl get pods | awk '{print $1}' | grep -E ^nginx) --all-containers=true --prefix=true
+      - name: check log postgres
+        if: always()
+        run: |
+          kubectl describe po $(kubectl get pods | awk '{print $1}' | grep -E ^postgres)
+          kubectl logs $(kubectl get pods | awk '{print $1}' | grep -E ^postgres) --all-containers=true --prefix=true
+      - name: check log mongodb
+        if: always()
+        run: |
+          kubectl describe po $(kubectl get pods | awk '{print $1}' | grep -E ^mongodb)
+          kubectl logs $(kubectl get pods | awk '{print $1}' | grep -E ^mongodb) --all-containers=true --prefix=true
+      - name: check log kafka
+        if: always()
+        run: |
+          kubectl describe po $(kubectl get pods | awk '{print $1}' | grep -E ^kafka)
+          kubectl logs $(kubectl get pods | awk '{print $1}' | grep -E ^kafka) --all-containers=true --prefix=true
+      - name: check log zookeeper
+        if: always()
+        run: |
+          kubectl describe po $(kubectl get pods | awk '{print $1}' | grep -E ^zookeeper)
+          kubectl logs $(kubectl get pods | awk '{print $1}' | grep -E ^zookeeper) --all-containers=true --prefix=true
       - name: check status
         if: always()
         run: |


### PR DESCRIPTION
## 概要
quarkus CI（minikube/kind）で新イメージ反映後に CrashLoop / ImagePullBackOff となっている DB pod 群のログ・describe を採取できるよう、診断ステップを追加する。原因特定のための調査用PR。

## 背景
PR #4091（docker-image-ci の push 条件修正）で `yurak/*:latest` が3年ぶりに最新化された結果、これまで古いイメージで隠れていた問題が顕在化：

- **nginx** `1/2`: 新 `nginx/1.31.2` が `/run/nginx.pid` に Permission denied で emerg 即死
- **mysql** `1/2`: 新 `mysql:9.7.1` が `/var/lib/mysql` に Permission denied で初期化失敗
- **postgres** `1/2` / **mongodb** `0/2` / **cassandra** `0/1`: CrashLoop（**ログ未採取で原因不明**）
- **kafka-0 / zookeeper-0**: ImagePullBackOff（**ログ未採取**）

## 変更
- `minikube-quarkus-ci.yml`: postgres・mongodb・kafka・zookeeper の describe + 全コンテナ logs ステップを追加（mysql/nginx/cassandra は既存）
- `kind-quarkus-ci.yml`: nginx・postgres・mongodb・cassandra・kafka・zookeeper の同ステップを追加（mysql は既存を利用）

いずれも `--all-containers=true --prefix=true` で sidecar 含む全コンテナを採取。

## 確認方法
本PRは両 quarkus CI ワークフローを変更するため PR 上で両 CI が走る。次の run で各 DB pod の真の crash 理由が採取されることを確認し、それを基に修正 PR を分けて出す。

🤖 Generated with [Claude Code](https://claude.com/claude-code)