### PR TITLE
fix(nginx): make pid path rewrite robust to /run vs /var/run

### DIFF
--- a/kubernetes/nginx/Dockerfile
+++ b/kubernetes/nginx/Dockerfile
@@ -10,7 +10,7 @@ COPY docs /etc/nginx/docs
 
 # Implement changes required to run NGINX as an unprivileged user
 RUN sed -i '/user  nginx;/d' /etc/nginx/nginx.conf \
-    && sed -i 's,/var/run/nginx.pid,/tmp/nginx.pid,' /etc/nginx/nginx.conf \
+    && sed -i -E 's,^[[:space:]]*pid[[:space:]]+.*;,pid /tmp/nginx.pid;,' /etc/nginx/nginx.conf \
     && sed -i "/^http {/a \    proxy_temp_path /tmp/proxy_temp;\n \
     client_body_temp_path /tmp/client_temp;\n    fastcgi_temp_path /tmp/fastcgi_temp;\n \
     uwsgi_temp_path /tmp/uwsgi_temp;\n    scgi_temp_path /tmp/scgi_temp;\n" /etc/nginx/nginx.conf \


### PR DESCRIPTION
## 概要
nginx pod の CrashLoopBackOff を修正する（quarkus CI 恒常fail の一因）。

## 原因（PR #4100 の診断ログで確定）
新イメージ `nginx/1.31.2` が起動時に emerg 即死していた：

```
[emerg] 1#1: open() "/run/nginx.pid" failed (13: Permission denied)
```

Dockerfile の pid 書き換え sed が **`/var/run/nginx.pid` 固定文字列**を対象にしていたが、近年の nginx 公式イメージは nginx.conf の pid ディレクティブが `/run/nginx.pid` に変わっており、**sed がマッチせず** pid が非root ユーザーの書けない `/run` のまま残っていた。

## 変更
pid 行全体をパスに依存せず置換する正規表現へ：

```diff
-    && sed -i 's,/var/run/nginx.pid,/tmp/nginx.pid,' /etc/nginx/nginx.conf \
+    && sed -i -E 's,^[[:space:]]*pid[[:space:]]+.*;,pid /tmp/nginx.pid;,' /etc/nginx/nginx.conf \
```

POSIX 文字クラスで BSD/GNU sed 双方に対応。`/var/run`・`/run` いずれの既定値でも `pid /tmp/nginx.pid;` に統一される。

## 確認方法
**このPR単体では quarkus CI は走らない**（quarkus CI の PR トリガはワークフローファイル変更時のみ、かつイメージ再ビルド・push は master push 時のみ）。マージ後に master の `docker-image-ci` が新 nginx イメージを push し、続く quarkus CI で nginx pod が `2/2` Ready になることを確認する。

## 補足
これは新イメージ最新化（#4091）で顕在化した複数の DB 権限問題のうちの1件目。postgres(v18マウント変更)・mysql・mongodb・cassandra の権限問題、および kafka/zookeeper の bitnami タグ消失は別PRで順次対応する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)