### PR TITLE
fix(postgres): mount volume at /var/lib/postgresql for v18+

### DIFF
--- a/kubernetes/postgres/postgres-deployment.yaml
+++ b/kubernetes/postgres/postgres-deployment.yaml
@@ -47,8 +47,10 @@ spec:
                 - -c
                 - psql -U postgres -c "SELECT 1;"
           volumeMounts:
+            # postgres 18+ requires a single mount at /var/lib/postgresql
+            # (data is placed in a major-version subdirectory beneath it).
             - name: postgres-persistent-storage
-              mountPath: /var/lib/postgresql/data
+              mountPath: /var/lib/postgresql
         - name: postgres-exporter
           image: wrouesnel/postgres_exporter:v0.8.0
           ports:


### PR DESCRIPTION
## 概要
postgres pod の CrashLoopBackOff を修正する（quarkus CI 恒常fail の一因）。

## 原因（PR #4100 の診断ログで確定）
新イメージ `postgres:18.4-alpine` が起動時に異常終了：

```
Error: in 18+, these Docker images are configured to store database data in a
       format which is compatible with "pg_ctlcluster" ...
         /var/lib/postgresql/data (unused mount/volume)
       The suggested container configuration for 18+ is to place a single mount
       at /var/lib/postgresql which will then place PostgreSQL data in a subdirectory
```

postgres 18+ の Docker イメージは、データをメジャーバージョン別サブディレクトリに格納する方式へ変更された。従来どおり `/var/lib/postgresql/data` に直接マウントすると "unused mount/volume" として起動が拒否される。

## 変更
volumeMount の mountPath を `/var/lib/postgresql/data` → `/var/lib/postgresql` へ変更。CI は空 PV から開始するためデータ移行は不要。

参考: https://github.com/docker-library/postgres/pull/1259

## 確認方法
マージ後、master の `docker-image-ci`（本イメージはベースイメージのため再ビルド不要だが）と quarkus CI で postgres pod が Ready になることを確認する。

## 補足
新イメージ最新化（#4091）で顕在化した権限/互換問題の対応シリーズ。nginx(#4103, merged) に続く2件目。残りは mysql・mongodb・cassandra の権限、kafka/zookeeper の bitnami タグ消失。

🤖 Generated with [Claude Code](https://claude.com/claude-code)