### PR TITLE
fix(mysql): set fsGroup so mysql user can write data directory

### DIFF
--- a/kubernetes/mysql/mysql-deployment.yaml
+++ b/kubernetes/mysql/mysql-deployment.yaml
@@ -19,6 +19,12 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9104"
     spec:
+      # mysql image runs as the non-root "mysql" user (uid/gid 999).
+      # fsGroup makes kubelet chown the mounted volume to that group so the
+      # data directory /var/lib/mysql is writable (fixes CrashLoop on
+      # "data directory ... is not writable").
+      securityContext:
+        fsGroup: 999
       containers:
         - name: mysql
           image: yurak/mysql:latest


### PR DESCRIPTION
## 概要
mysql pod の CrashLoopBackOff を修正する（quarkus CI・chaos-mesh CI 恒常fail の一因）。

## 原因（PR #4100 の診断ログで確定）
新イメージ `mysql:9.7.1` が初期化に失敗：

```
--initialize specified but the data directory exists and is not writable. Aborting.
The designated data directory /var/lib/mysql/ is unusable.
mysqld: Can't create/write to file '/var/lib/mysql/is_writable' (OS errno 13 - Permission denied)
```

Dockerfile の `USER mysql`（非root, uid/gid 999）でコンテナが動く一方、マウントされる hostPath PV は root 所有のため mysql ユーザーが `/var/lib/mysql` に書き込めない。旧イメージ（8.0.32、`USER mysql` 追加前）では表面化していなかったが、#4091 でイメージが最新化され顕在化した。

## 変更
pod の `securityContext.fsGroup: 999` を設定。kubelet がマウントボリュームを mysql グループ書込可へ chown する。

## 確認方法
マージ後、master の quarkus CI で mysql pod が `2/2` Ready になること、また mysql 起因で失敗していた chaos-mesh CI も回復することを確認する。

## 補足
新イメージ最新化（#4091）で顕在化した権限/互換問題の対応シリーズ。nginx(#4103)・postgres(#4105) に続く3件目。残りは mongodb・cassandra の権限、kafka/zookeeper の bitnami タグ消失。

🤖 Generated with [Claude Code](https://claude.com/claude-code)