### PR TITLE
fix(mysql): chown data dir via initContainer (fsGroup fails on hostPath)

### DIFF
--- a/kubernetes/mysql/mysql-deployment.yaml
+++ b/kubernetes/mysql/mysql-deployment.yaml
@@ -19,12 +19,18 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9104"
     spec:
-      # mysql image runs as the non-root "mysql" user (uid/gid 999).
-      # fsGroup makes kubelet chown the mounted volume to that group so the
-      # data directory /var/lib/mysql is writable (fixes CrashLoop on
-      # "data directory ... is not writable").
-      securityContext:
-        fsGroup: 999
+      # mysql image runs as the non-root "mysql" user (uid/gid 999), but the
+      # hostPath-backed PV is owned by root and fsGroup does not apply to
+      # hostPath volumes. chown the data directory up front so mysql can
+      # write it (fixes CrashLoop on "data directory ... is not writable").
+      initContainers:
+        - name: init-chown-data
+          image: busybox:latest
+          imagePullPolicy: Always
+          command: ["chown", "-R", "999:999", "/var/lib/mysql"]
+          volumeMounts:
+            - name: mysql-persistent-storage
+              mountPath: /var/lib/mysql
       containers:
         - name: mysql
           image: yurak/mysql:latest


### PR DESCRIPTION
## 概要
mysql pod の CrashLoopBackOff を修正する（#4106 の fsGroup 方式が効かなかったための再修正）。

## 経緯
#4106 で `securityContext.fsGroup: 999` を入れたが、master 反映後の quarkus CI で検証したところ mysql は依然 `/var/lib/mysql` permission denied で CrashLoop したままだった。

**原因**: 当リポジトリの mysql PVC は hostPath PV（`/data/pv001`、root所有）にバインドされている。`fsGroup` は emptyDir や CSI ボリュームには chown を適用するが、**hostPath ボリュームには適用されない**（kubelet は hostPath の所有権を変更しない）。そのため uid 999 の mysql ユーザーが書けないままだった。

## 変更
fsGroup を廃し、root 実行の initContainer で `/var/lib/mysql` を `chown -R 999:999` してから main を起動する方式に変更（リポジトリ既存の prometheus `init-chown-data` と同じパターン）。

## 確認方法
マージ後、master の quarkus CI で mysql pod が `2/2` Ready になること、mysql 起因で失敗していた chaos-mesh CI も回復することを確認する。

## 補足
同じ hostPath+fsGroup 問題は mongodb(#4107)・postgres・cassandra にも該当するため、それぞれ initContainer 方式へ揃える。

🤖 Generated with [Claude Code](https://claude.com/claude-code)