### PR TITLE
fix(postgres): chown data dir via initContainer for hostPath PV

### DIFF
--- a/kubernetes/postgres/postgres-deployment.yaml
+++ b/kubernetes/postgres/postgres-deployment.yaml
@@ -19,6 +19,18 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9187"
     spec:
+      # postgres image runs as the non-root "postgres" user (uid/gid 70 on
+      # alpine), but the hostPath-backed PV is owned by root and fsGroup does
+      # not apply to hostPath volumes. chown the data directory up front so
+      # postgres can write it.
+      initContainers:
+        - name: init-chown-data
+          image: busybox:latest
+          imagePullPolicy: Always
+          command: ["chown", "-R", "70:70", "/var/lib/postgresql"]
+          volumeMounts:
+            - name: postgres-persistent-storage
+              mountPath: /var/lib/postgresql
       containers:
         - name: postgres
           image: yurak/postgres:latest


### PR DESCRIPTION
## 概要
postgres pod の CrashLoopBackOff を修正する（#4105 のマウント修正に続く2段目）。

## 経緯
#4105 で v18 仕様に合わせマウントパスを `/var/lib/postgresql` に直したが、それでも postgres pod は起動できない。hostPath-backed PV（root所有）に対し、非root の postgres ユーザ（alpine では **uid/gid 70**）が書き込めないため。`fsGroup` は hostPath には適用されない（#4106/#4108 の mysql と同じ問題）。

## 変更
root 実行の initContainer で `/var/lib/postgresql` を `chown -R 70:70` してから main を起動する（リポジトリ既存の prometheus `init-chown-data` と同じパターン）。

## 確認方法
マージ後、master の quarkus CI で postgres pod が Ready になることを確認する。

## 補足
新イメージ最新化（#4091）で顕在化した hostPath 権限問題の対応。mysql(#4108)・mongodb(#4107) と同じ initContainer 手法。cassandra はデータディレクトリ不一致という別要因のため別途対応、kafka/zookeeper は bitnami タグ消失で別途対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)