### PR TITLE
fix(cassandra): mount PV at data dir and chown via initContainer

### DIFF
--- a/kubernetes/cassandra/cassandra-statefulset.yaml
+++ b/kubernetes/cassandra/cassandra-statefulset.yaml
@@ -18,6 +18,19 @@ spec:
         app: cassandra
     spec:
       terminationGracePeriodSeconds: 1800
+      # cassandra image runs as the non-root "cassandra" user (uid/gid 999),
+      # but the hostPath-backed PV is owned by root and fsGroup does not apply
+      # to hostPath volumes. chown the data directory up front so cassandra can
+      # write it (fixes CrashLoop on
+      # "AccessDeniedException: /opt/cassandra/data/commitlog").
+      initContainers:
+        - name: init-chown-data
+          image: busybox:latest
+          imagePullPolicy: Always
+          command: ["chown", "-R", "999:999", "/opt/cassandra/data"]
+          volumeMounts:
+            - name: cassandra-persistent-storage
+              mountPath: /opt/cassandra/data
       containers:
         - name: cassandra
           image: yurak/cassandra:latest
@@ -71,8 +84,11 @@ spec:
             initialDelaySeconds: 15
             timeoutSeconds: 5
           volumeMounts:
+            # cassandra 5.0 stores data under $CASSANDRA_HOME/data
+            # (/opt/cassandra/data), not /var/lib/cassandra, so mount the PV
+            # there to persist data and match the chown above.
             - name: cassandra-persistent-storage
-              mountPath: /var/lib/cassandra
+              mountPath: /opt/cassandra/data
       volumes:
         - name: cassandra-persistent-storage
           persistentVolumeClaim:


### PR DESCRIPTION
## 概要
cassandra pod の CrashLoopBackOff を修正する（quarkus CI 恒常fail の一因）。

## 原因（PR #4100 の診断ログで確定）
新イメージ `cassandra:5.0` が起動時に異常終了：

```
Exception (org.apache.cassandra.io.FSWriteError) encountered during startup:
java.nio.file.AccessDeniedException: /opt/cassandra/data/commitlog
```

2つの要因が重なっていた：
1. **データディレクトリの不一致**: cassandra 5.0 のデータは `$CASSANDRA_HOME/data`（`/opt/cassandra/data`）に書かれるが、PV は使われない `/var/lib/cassandra` にマウントされていた。実データはイメージ層に書かれ永続化されず、書込権限もない。
2. **権限**: Dockerfile の `USER cassandra`（非root, uid/gid 999）で動くが、その書込先が非rootで書けず AccessDenied。

## 変更
- PV マウント先を実データディレクトリ `/opt/cassandra/data` に変更（データが正しく永続化される）。
- root 実行の initContainer で `/opt/cassandra/data` を `chown -R 999:999` してから main を起動（他DB #4107/#4108/#4109 と同じ `init-chown-data` パターン）。

## 確認方法
マージ後、master の quarkus CI で cassandra pod が Ready になることを確認する。

## 補足
新イメージ最新化（#4091）で顕在化した権限/互換問題の対応シリーズ。nginx/mysql/mongodb/postgres は回復実証済み。残るは kafka/zookeeper の bitnami タグ消失（別途）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)