### PR TITLE
fix(ci): scope check-for-update README sed to each badge (stop JVM badge corruption)

### DIFF
--- a/.github/workflows/check-for-update.yml
+++ b/.github/workflows/check-for-update.yml
@@ -52,7 +52,7 @@ jobs:
           sed -i -e "s/$SOURCE_YAML_VERSION/$TARGET_MINIKUBE_VERSION/g" minikube-yaml-ci.yml
           sed -i -e "s/$SOURCE_STRESS_VERSION/$TARGET_MINIKUBE_VERSION/g" minikube-stress-ci.yml
           sed -i -e "s/$SOURCE_SECURITY_VERSION/$TARGET_MINIKUBE_VERSION/g" minikube-security-ci.yml
-          sed -i -e "s/$SOURCE_DOC_VERSION/$TARGET_MINIKUBE_VERSION/g" ../../README.md
+          sed -i -e "s#badge/Minikube-$SOURCE_DOC_VERSION-#badge/Minikube-$TARGET_MINIKUBE_VERSION-#" ../../README.md
       - name: Add, commit, push, and create PR
         if: env.UNMATCH_VERSION == 'true' && env.BRANCH_IS_EXISTING == 'false'
         uses: peter-evans/create-pull-request@v8.1.1
@@ -110,7 +110,7 @@ jobs:
           sed -i -e "s/$SOURCE_YAML_VERSION/$TARGET_KUBERNETES_VERSION/g" minikube-yaml-ci.yml
           sed -i -e "s/$SOURCE_STRESS_VERSION/$TARGET_KUBERNETES_VERSION/g" minikube-stress-ci.yml
           sed -i -e "s/$SOURCE_SECURITY_VERSION/$TARGET_KUBERNETES_VERSION/g" minikube-security-ci.yml
-          sed -i -e "s/$SOURCE_DOC_VERSION/$TARGET_KUBERNETES_VERSION/g" ../../README.md
+          sed -i -e "s#badge/Kubernetes-$SOURCE_DOC_VERSION-#badge/Kubernetes-$TARGET_KUBERNETES_VERSION-#" ../../README.md
       - name: Add, commit, push, and create PR
         if: env.UNMATCH_VERSION == 'true' && env.BRANCH_IS_EXISTING == 'false'
         uses: peter-evans/create-pull-request@v8.1.1
@@ -160,7 +160,7 @@ jobs:
         working-directory: ./.github/workflows
         run: |
           sed -i -e "s/$SOURCE_VERSION/$TARGET_VERSION/g" kind-chaos-mesh-ci.yml
-          sed -i -e "s/$SOURCE_DOC_VERSION/$TARGET_VERSION/g" ../../README.md
+          sed -i -e "s#badge/kind-$SOURCE_DOC_VERSION-#badge/kind-$TARGET_VERSION-#" ../../README.md
       - name: Add, commit, push, and create PR
         if: env.UNMATCH_VERSION == 'true' && env.BRANCH_IS_EXISTING == 'false'
         uses: peter-evans/create-pull-request@v8.1.1
@@ -205,7 +205,7 @@ jobs:
       - name: update quarkus version
         if: env.UNMATCH_VERSION == 'true' && env.BRANCH_IS_EXISTING == 'false'
         run: |
-          sed -i -e "s/$SOURCE_VERSION/$TARGET_VERSION/g" README.md
+          sed -i -e "s#badge/Quarkus-$SOURCE_VERSION-#badge/Quarkus-$TARGET_VERSION-#" README.md
       - name: Add, commit, push, and create PR
         if: env.UNMATCH_VERSION == 'true' && env.BRANCH_IS_EXISTING == 'false'
         uses: peter-evans/create-pull-request@v8.1.1


### PR DESCRIPTION
## 概要
`check-for-update` ワークフローが README バッジを更新する際、無限定のグローバル sed で他バッジを巻き込んで破壊していた問題を根本修正します。

## 原因
minikube / kubernetes / chaos-mesh(kind) / quarkus の4ジョブは、README を次のように更新していました:
```
sed -i -e "s/$SOURCE/$TARGET/g" README.md
```
- README の Support バッジ5種は**1行に連結**されている
- **Kubernetes と Minikube は同値**（1.38.1）
- そのため `s/1.38.1/.../g` が意図しないバッジを巻き込み、
  - JVM バッジを破壊（`JVM-17` → `JVM-1.38.1`、#4104 で実際に発生し #4111 で手動修復）
  - 同値の Kubernetes/Minikube を相互に誤更新

## 修正
各置換をバッジの shields.io スラッグ `badge/<Label>-<version>-` にアンカーし、`/g` を除去（1バッジ1回のみ置換）:
```
sed -i -e "s#badge/Minikube-$SOURCE-#badge/Minikube-$TARGET-#" ../../README.md
```
minikube / kubernetes / kind / quarkus の4箇所に適用。

## 検証（ローカル）
Minikube / Kubernetes / kind / Quarkus のいずれを更新しても、**他バッジ（JVM-17 含む）が一切変化しない**ことを確認済み。Kubernetes と Minikube が同値でも取り違えません。

## 関連
- #4104（JVMバッジ破壊）→ #4111 で手動修復済み。本PRで再発を根絶。
- 現在オープンの #4115（同じ破壊を含む自動PR）は本修正が入れば不要のためクローズ推奨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)