### PR TITLE
fix(kafka,zookeeper): pull images from bitnamilegacy repo

### DIFF
--- a/kubernetes/kafka/kafka-statefulset.yaml
+++ b/kubernetes/kafka/kafka-statefulset.yaml
@@ -18,7 +18,9 @@ spec:
     spec:
       containers:
         - name: kafka
-          image: bitnami/kafka:3.9.0-debian-12-r13
+          # Bitnami moved free/legacy image tags to the "bitnamilegacy" repo
+          # on 2025-08-28; bitnami/kafka no longer serves versioned tags.
+          image: bitnamilegacy/kafka:3.9.0-debian-12-r13
           imagePullPolicy: Always
           ports:
             - containerPort: 9092

--- a/kubernetes/zookeeper/zookeeper-statefulset.yaml
+++ b/kubernetes/zookeeper/zookeeper-statefulset.yaml
@@ -21,7 +21,9 @@ spec:
     spec:
       containers:
         - name: zookeeper
-          image: bitnami/zookeeper:3.9.3-debian-12-r22
+          # Bitnami moved free/legacy image tags to the "bitnamilegacy" repo
+          # on 2025-08-28; bitnami/zookeeper no longer serves versioned tags.
+          image: bitnamilegacy/zookeeper:3.9.3-debian-12-r22
           imagePullPolicy: Always
           ports:
             - containerPort: 2181

--- a/renovate.json
+++ b/renovate.json
@@ -28,6 +28,11 @@
     {
       "matchPackageNames": ["webapp.3tier.k8s.parent:parent-pom"],
       "enabled": false
+    },
+    {
+      "description": "bitnamilegacy is a frozen archive repo (post 2025-08-28 Bitnami migration); no updates are published there.",
+      "matchPackageNames": ["bitnamilegacy/**"],
+      "enabled": false
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## 概要
kafka-0 / zookeeper-0 pod の ImagePullBackOff を修正する（quarkus CI 恒常fail の一因）。

## 原因（PR #4100 の診断ログで確定）
```
Failed to pull image "bitnami/kafka:3.9.0-debian-12-r13": not found
Failed to pull image "bitnami/zookeeper:3.9.3-debian-12-r22": not found
```

Bitnami は **2025-08-28 に無料コンテナイメージの提供方針を変更**し、バージョン付き既存タグを `docker.io/bitnami` から `docker.io/bitnamilegacy` アーカイブリポジトリへ移動した。このため `bitnami/kafka`・`bitnami/zookeeper` は該当タグ（および latest すら）を提供しなくなり pull 不可になった。

## 変更
- 同一バージョンが `bitnamilegacy` に現存することを確認済み。イメージ参照を `bitnamilegacy/kafka:3.9.0-debian-12-r13` / `bitnamilegacy/zookeeper:3.9.3-debian-12-r22` に向け直す。
- `bitnamilegacy` は更新されない凍結アーカイブのため、Renovate が無駄な更新/エラーを出さないよう当該パッケージを無効化。

## 確認方法
マージ後、master の quarkus CI で kafka-0 / zookeeper-0 が起動し Ready になることを確認する。

## 補足
これで #4091（イメージ最新化）で顕在化した全 DB/ミドルウェア障害（nginx/mysql/mongodb/postgres/cassandra/kafka/zookeeper）の修正が出揃う。将来的には apache/kafka 公式イメージ（KRaftモード、zookeeper不要）への移行も選択肢だが、本PRは pull 不能の即時解消を優先した最小変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)