### PR TITLE
fix(cassandra): add startupProbe so liveness waits for slow startup

### DIFF
--- a/kubernetes/cassandra/cassandra-statefulset.yaml
+++ b/kubernetes/cassandra/cassandra-statefulset.yaml
@@ -68,6 +68,15 @@ spec:
               value: "GossipingPropertyFileSnitch"
             - name: CASSANDRA_KEYSPACE
               value: "webapp"
+          # cassandra 5.0 takes ~1-2 min to open the CQL port (9042). Without a
+          # startupProbe the livenessProbe fired during startup and the kubelet
+          # killed the container (drain -> exit 143) in a CrashLoop. The
+          # startupProbe holds liveness off until the port is up (max 5 min).
+          startupProbe:
+            tcpSocket:
+              port: 9042
+            periodSeconds: 10
+            failureThreshold: 30
           livenessProbe:
             tcpSocket:
               port: 9042
@@ -84,9 +93,9 @@ spec:
             initialDelaySeconds: 15
             timeoutSeconds: 5
           volumeMounts:
-            # cassandra 5.0 stores data under $CASSANDRA_HOME/data
-            # (/opt/cassandra/data), not /var/lib/cassandra, so mount the PV
-            # there to persist data and match the chown above.
+            # cassandra 5.0 places the commitlog under storagedir
+            # (/opt/cassandra/data/commitlog), so mount the PV there and chown
+            # it (see initContainer) to fix the startup AccessDeniedException.
             - name: cassandra-persistent-storage
               mountPath: /opt/cassandra/data
       volumes:


### PR DESCRIPTION
## 概要
cassandra pod の CrashLoopBackOff を解消する（#4116 の権限修正に続く2段目、これで完全回復見込み）。

## 経緯
#4116 で `/opt/cassandra/data/commitlog` の AccessDenied（権限）は解消し、cassandra は正常に起動プロセスを開始するようになった。しかし依然 CrashLoopBackOff で、**原因は権限ではなく probe のタイミング**だった。

診断ログ（最新 master run）で確定：
- cassandra は `Flushing ... system.local` 等まで正常進行
- だが `livenessProbe: tcpSocket 9042` に起動猶予（initialDelay/startupProbe）が無く、cassandra 5.0 の重い起動（CQLポート9042開放まで約1-2分）の途中で failure×3 に到達
- kubelet が kill → preStop の `nodetool drain` → `DRAINED` / `shutdown complete`（Exit Code 143）→ CrashLoop（Restart 7回）

## 変更
- `startupProbe`（tcp :9042, periodSeconds 10, failureThreshold 30 = 最大5分）を追加。起動完了まで liveness/readiness を保留する。
- #4116 で付けたデータディレクトリのコメントを、実挙動（commitlog が storagedir 配下 `/opt/cassandra/data/commitlog` に置かれる）に即した内容へ修正。

## 確認方法
マージ後、master の quarkus CI で cassandra pod が `1/1` Ready になることを確認する。

## 補足
これで #4091 起点の全 DB/ミドルウェア障害（nginx/mysql/mongodb/postgres/cassandra/kafka/zookeeper）が解消する見込み。kafka/zookeeper は #4121 で回復実証済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)